### PR TITLE
[FEATURE] Add priority tag to img-wrap

### DIFF
--- a/app/components/img-wrap.js
+++ b/app/components/img-wrap.js
@@ -4,7 +4,7 @@ import ImgManagerInViewportMixin from '../mixins/img-manager/in-viewport';
 var IMG_ATTRIBUTES = [
   'id', 'title', 'align', 'alt', 'border', 'height',
   'hspace', 'ismap', 'longdesc', 'name', 'width',
-  'usemap', 'vspace'
+  'usemap', 'vspace', 'priority'
 ];
 
 var computed = Ember.computed;
@@ -241,7 +241,11 @@ ImgWrapComponent = Ember.Component.extend(ImgManagerInViewportMixin, {
     var imgSource = this.get('imgSource');
     if (imgSource && this._state === 'inDOM' && this.get('enteredViewport')) {
       //Ember.debug('[img-manager] Scheduling load for `' + imgSource.get('src') + '`.');
-      imgSource.scheduleLoad();
+      if (this.get('priority') === true) {
+        imgSource.scheduleLoad(false, 'priority');
+      } else {
+        imgSource.scheduleLoad();
+      }
     }
   }),
 

--- a/app/utils/img-manager/img-rule.js
+++ b/app/utils/img-manager/img-rule.js
@@ -216,7 +216,13 @@ export default Ember.Object.extend({
     else {
       args = slice.call(arguments, 2);
     }
-    this.get('_loadQueue').pushObject([target, method, args]);
+    var loadQueue = this.get('_loadQueue');
+    if (args.indexOf('priority') === -1) {
+      loadQueue.pushObject([target, method, args]);
+    }
+    else {
+      loadQueue.unshiftObject([target, method, args]);
+    }
     this.processLoadQueue();
   },
 

--- a/app/utils/img-manager/img-source.js
+++ b/app/utils/img-manager/img-source.js
@@ -369,13 +369,13 @@ export default Ember.Object.extend(Ember.Evented, {
    * @param {boolean} [forceReload=false]
    * @private
    */
-  scheduleLoad: function (forceReload) {
+  scheduleLoad: function (forceReload, priority) {
     var initiated = this.get('isInitiated');
     if (initiated && forceReload) {
       this.set('isInitiated', initiated = false);
     }
     if (!initiated) {
-      this.get('rule').scheduleForLoad(this, 'load');
+      this.get('rule').scheduleForLoad(this, 'load', priority);
     }
   },
 


### PR DESCRIPTION
When the priority tag is set on the img-wrap element this img will be placed on top of the loadQueue. This allows us to specify which images should be loaded with priority.
I needed this to make sure the first image of a carousel is loaded as first.
