### PR TITLE
Upgrade to Ember-CLI 2.11.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "ember": "~2.4.1",
     "ember-cli-shims": "0.1.0",
-    "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Huafu Gandon <huafu.gandon@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.2.0",
+    "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
     "ember-cli": "^2.11.1",
     "ember-cli-app-version": "^2.0.0",
@@ -29,6 +29,7 @@
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "0.2.9",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.12.2",
     "ember-disable-prototype-extensions": "^1.1.0",
@@ -36,8 +37,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^2.0.3",
-    "ember-try": "^0.2.13",
-    "loader.js": "^4.2.3"
+    "loader.js": "^4.0.10"
   },
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-img-manager",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "An `<img>` manager for Ember with cache, batch load and error handling.",
   "directories": {
     "doc": "doc",
@@ -13,31 +13,31 @@
   },
   "repository": "https://github.com/huafu/ember-img-manager",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "author": "Huafu Gandon <huafu.gandon@gmail.com>",
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-ajax": "0.7.1",
-    "ember-cli": "2.4.1",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.2.1",
-    "ember-cli-release": "0.2.8",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "^2.11.1",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-release": "0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.4.0",
+    "ember-data": "^2.12.2",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-export-application-global": "^1.0.4",
-    "ember-load-initializers": "^0.5.0",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^2.0.3",
-    "ember-try": "^0.1.2",
-    "loader.js": "^4.0.0"
+    "ember-try": "^0.2.13",
+    "loader.js": "^4.2.3"
   },
   "keywords": [
     "ember-addon",
@@ -49,7 +49,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/acceptance/img-wrap/delayed-src-test.js
+++ b/tests/acceptance/img-wrap/delayed-src-test.js
@@ -3,28 +3,28 @@ import { module, test } from 'qunit';
 import startApp from '../../helpers/start-app';
 
 
-var App;
+let App;
 
 module('Acceptance: should update the image after the src changed with a delay', {
-  setup: function () {
+  beforeEach: function () {
     App = startApp();
   },
-  teardown: function () {
+  afterEach: function () {
     Ember.run(App, 'destroy');
   }
 });
 
-test('visiting /img-wrap/delayed-src', function () {
-  var $imgContainer;
+test('visiting /img-wrap/delayed-src', function (assert) {
+  let $imgContainer;
   visit('/img-wrap/delayed-src');
   andThen(function () {
     fillIn('#img-src', 'assets/images/cartoon-1.jpg');
     later(100);
   });
   andThen(function () {
-    equal(currentPath(), 'img-wrap.delayed-src');
+    assert.equal(currentPath(), 'img-wrap.delayed-src');
     $imgContainer = find('.img-container');
-    equal($imgContainer.find('img').attr('src'), 'assets/images/cartoon-1.jpg');
-    equal($imgContainer.find('img').attr('alt'), 'Cartoon 1');
+    assert.equal($imgContainer.find('img').attr('src'), 'assets/images/cartoon-1.jpg');
+    assert.equal($imgContainer.find('img').attr('alt'), 'Cartoon 1');
   });
 });

--- a/tests/acceptance/img-wrap/hooks-test.js
+++ b/tests/acceptance/img-wrap/hooks-test.js
@@ -3,22 +3,22 @@ import { module, test } from 'qunit';
 import startApp from '../../helpers/start-app';
 
 
-var VALID_SRC = 'assets/images/cartoon-1.jpg';
-var INVALID_SRC = '__dummy_not_exists__.jpg';
+let VALID_SRC = 'assets/images/cartoon-1.jpg';
+let INVALID_SRC = '__dummy_not_exists__.jpg';
 
-var App;
+let App;
 
 module('Acceptance: should trigger the `load-success` and `load-error` hooks', {
-  setup:    function () {
+  beforeEach:    function () {
     App = startApp();
   },
-  teardown: function () {
+  afterEach: function () {
     Ember.run(App, 'destroy');
   }
 });
 
-test('visiting /img-wrap/hooks', function () {
-  var $img1Container, $img2Container, $img3Container, controller;
+test('visiting /img-wrap/hooks', function (assert) {
+  let $img1Container, $img2Container, $img3Container, controller;
   visit('/img-wrap/hooks');
   andThen(function(){
     controller = controllerFor('img-wrap/hooks');
@@ -28,7 +28,7 @@ test('visiting /img-wrap/hooks', function () {
     later(50);
   });
   andThen(function(){
-    ok(!controller.hooked(), 'No hook should have been called yet');
+    assert.ok(!controller.hooked(), 'No hook should have been called yet');
     controller.setProperties({
       imgSrc1: VALID_SRC,
       imgSrc2: VALID_SRC,
@@ -37,10 +37,10 @@ test('visiting /img-wrap/hooks', function () {
     later(50);
   });
   andThen(function () {
-    ok(controller.hooked('success', 1), 'Success should have been called for img 1');
-    ok(controller.hooked('success', 2), 'Success should have been called for img 2');
-    ok(controller.hooked('success', 3), 'Success should have been called for img 3');
-    equal(controller.hookeds().length, 3, 'Only 3 hooks should have been called');
+    assert.ok(controller.hooked('success', 1), 'Success should have been called for img 1');
+    assert.ok(controller.hooked('success', 2), 'Success should have been called for img 2');
+    assert.ok(controller.hooked('success', 3), 'Success should have been called for img 3');
+    assert.equal(controller.hookeds().length, 3, 'Only 3 hooks should have been called');
     controller.resetHooks();
     controller.setProperties({
       imgSrc1: INVALID_SRC,
@@ -50,10 +50,10 @@ test('visiting /img-wrap/hooks', function () {
     later(50);
   });
   andThen(function () {
-    ok(controller.hooked('error', 1), 'Error should have been called for img 1');
-    ok(controller.hooked('error', 2), 'Error should have been called for img 2');
-    ok(controller.hooked('error', 3), 'Error should have been called for img 3');
-    equal(controller.hookeds().length, 3, 'Only 3 hooks should have been called');
+    assert.ok(controller.hooked('error', 1), 'Error should have been called for img 1');
+    assert.ok(controller.hooked('error', 2), 'Error should have been called for img 2');
+    assert.ok(controller.hooked('error', 3), 'Error should have been called for img 3');
+    assert.equal(controller.hookeds().length, 3, 'Only 3 hooks should have been called');
     controller.resetHooks();
   });
 });

--- a/tests/acceptance/img-wrap/simple-test.js
+++ b/tests/acceptance/img-wrap/simple-test.js
@@ -1,27 +1,29 @@
 import Ember from 'ember';
 import startApp from '../../helpers/start-app';
+import { module, test } from 'qunit';
 
-var application;
+let application;
 
 module('Acceptance: should render a simple image', {
-  setup:    function () {
+  beforeEach:    function () {
     application = startApp();
   },
-  teardown: function () {
+  afterEach: function () {
     Ember.run(application, 'destroy');
   }
 });
 
-test('visiting /img-wrap/simple', function () {
-  var $imgContainer;
+test('visiting /img-wrap/simple', function (assert) {
+  assert.equal(true, true);
+  let $imgContainer;
   visit('/img-wrap/simple');
   andThen(function(){
     later(10);
   });
   andThen(function () {
-    equal(currentPath(), 'img-wrap.simple');
+    assert.equal(currentPath(), 'img-wrap.simple');
     $imgContainer = find('.img-container');
-    equal($imgContainer.find('img').attr('src'), 'assets/images/cartoon-1.jpg');
-    equal($imgContainer.find('img').attr('alt'), 'Cartoon 1');
+    assert.equal($imgContainer.find('img').attr('src'), 'assets/images/cartoon-1.jpg');
+    assert.equal($imgContainer.find('img').attr('alt'), 'Cartoon 1');
   });
 });

--- a/tests/acceptance/img-wrap/switch-src-test.js
+++ b/tests/acceptance/img-wrap/switch-src-test.js
@@ -1,30 +1,31 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+import { module } from 'qunit';
+import { test } from 'qunit';
 import startApp from '../../helpers/start-app';
 
-var App;
+let App;
 
 module('Acceptance: should update the image after the src changed', {
-  setup:    function () {
+  beforeEach:    function () {
     App = startApp();
   },
-  teardown: function () {
+  afterEach: function () {
     Ember.run(App, 'destroy');
   }
 });
 
-test('visiting /img-wrap/delayed-src', function () {
-  var $imgContainer;
+test('visiting /img-wrap/delayed-src', function (assert) {
+  let $imgContainer;
   visit('/img-wrap/delayed-src');
   andThen(function(){
     fillIn('#img-src', 'assets/images/cartoon-1.jpg');
     later(10);
   });
   andThen(function () {
-    equal(currentPath(), 'img-wrap.delayed-src');
+    assert.equal(currentPath(), 'img-wrap.delayed-src');
     $imgContainer = find('.img-container');
-    equal($imgContainer.find('img').attr('src'), 'assets/images/cartoon-1.jpg');
-    equal($imgContainer.find('img').attr('alt'), 'Cartoon 1');
+    assert.equal($imgContainer.find('img').attr('src'), 'assets/images/cartoon-1.jpg');
+    assert.equal($imgContainer.find('img').attr('alt'), 'Cartoon 1');
   });
   andThen(function(){
     fillIn('#img-src', 'assets/images/cartoon-2.jpg');

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
@@ -29,7 +29,8 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
+    ENV.testPicURL = '/tests/dummy/public';
+    ENV.rootURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,10 +10,11 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
-
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <!-- Modification of baseURL: https://www.emberjs.com/blog/2016/04/28/baseURL.html -->
+    <base href="/" /> 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
@@ -21,12 +22,12 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
+    <script src="{{rootURL}}assets/test-loader.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
I upgraded the project to ember-cli 2.11.1 (also upgrades many of the other modules).  I was unable to use this addon in our project without this update.

Ember tests pass and Ember server is running without warnings.
I also tested it with my own project and it seems to work well.

- baseURL was deprecated but converting to rootURL did not fix the tests.  Adding `<base href="/>` to the test's `index.html` file allowed the tests to run properly.
https://www.emberjs.com/blog/2016/04/28/baseURL.html
- moved the `ember-cli-test-loader` from bower to an npm module based on deprecation warnings
- updated the setup & teardown of tests to the new way